### PR TITLE
Clarify why Python’s http.server is not enough

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ curl http://localhost:8000/index.html
 ...
 ```
 
-But when used to serve up single-page applications, a `404` is returned whenever one of the pages is accessed directly:
+But when used to serve up single-page applications, a `404` is returned whenever any page other than the index is accessed directly:
 
 ```
 $ curl http://localhost:8000/login
@@ -28,7 +28,7 @@ $ curl http://localhost:8000/login
 ...
 ```
 
-This project builds on the existing web server code to forward all requests to the index.
+This project builds on the existing web server code to forward all requests to the index. The single-page application’s client-side routing can then display the page that corresponds to that request’s URL.
 
 # Setup
 


### PR DESCRIPTION
When I first read this README, I was confused why you would want to always redirect to the index. Trying to understand the example, I thought,

> Why would you get a 404 when visiting `/login`? Is it because you didn’t define a `/login` page in your hypothetical app?

In my head, I was thinking that a single-page application just means any big JavaScript application.

This explicitly states that SPAs do client-side routing, and summarizes how client-side routing works. That should allow readers without SPA-writing experience to more easily understand the need for this software.
